### PR TITLE
Migrate from @hapi/joi to joi package

### DIFF
--- a/dist/Utils.js
+++ b/dist/Utils.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.propertiesToJson = exports.extractRef = exports.jsonToRef = exports.jsonToRegex = exports.regexToString = exports.isFunction = exports.isStringFunction = exports.isObject = void 0;
-var Joi = require("@hapi/joi");
+var Joi = require("joi");
 var index_1 = require("./index");
 function isObject(obj) {
     return obj !== null && typeof obj === "object" && !Array.isArray(obj);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,7 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.toJson = exports.fromJson = void 0;
-var Joi = require("@hapi/joi");
+var Joi = require("joi");
 var lodash_1 = require("lodash");
 var Utils_1 = require("./Utils");
 var OptionKey = {

--- a/dts/Interfaces/index.d.ts
+++ b/dts/Interfaces/index.d.ts
@@ -1,4 +1,4 @@
-import { ArraySortOptions, Base64Options, DataUriOptions, DomainOptions, EmailOptions, GuidOptions, HexOptions, HierarchySeparatorOptions, IpOptions, LanguageMessages, ObjectPatternOptions, PresenceMode, RenameOptions, RuleOptions, StringRegexOptions, UriOptions, ValidationOptions, WhenOptions, WhenSchemaOptions, Context, ReferenceOptions } from "@hapi/joi";
+import { ArraySortOptions, Base64Options, DataUriOptions, DomainOptions, EmailOptions, GuidOptions, HexOptions, HierarchySeparatorOptions, IpOptions, LanguageMessages, ObjectPatternOptions, PresenceMode, RenameOptions, RuleOptions, StringRegexOptions, UriOptions, ValidationOptions, WhenOptions, WhenSchemaOptions, Context, ReferenceOptions } from "joi";
 export interface Reference extends Omit<ReferenceOptions, "adjust"> {
     $ref: string;
     adjust?: string;

--- a/dts/Utils.d.ts
+++ b/dts/Utils.d.ts
@@ -1,4 +1,4 @@
-import * as Joi from "@hapi/joi";
+import * as Joi from "joi";
 import { JsonRegex } from "./Interfaces";
 export declare function isObject(obj: any): boolean;
 export declare function isStringFunction(str: string): boolean;

--- a/dts/index.d.ts
+++ b/dts/index.d.ts
@@ -1,4 +1,4 @@
-import * as Joi from "@hapi/joi";
+import * as Joi from "joi";
 import { Schema, AnySchema, ObjectSchema, StringSchema, ArraySchema, AlternativesSchema, BinarySchema, BooleanSchema, DateSchema, NumberSchema, LinkSchema, SymbolSchema } from "./Interfaces";
 export declare function fromJson(_json: Schema): Joi.Schema;
 export declare function toJson(joi: any): Schema;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Converts json from and to Joi objects.",
   "license": "MIT",
   "dependencies": {
-    "joi": "^17.2.1",
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@types/hapi__joi": "17.1.0",
     "@types/lodash": "^4.14.158",
     "@types/mocha": "^7.0.2",
+    "@types/node": "14.14.10",
+    "joi": "17.3.0",
     "mocha": "^7.1.2",
     "typescript": "^3.9.3"
   },
@@ -22,6 +22,9 @@
   "scripts": {
     "build": "rm -rf dist/* && rm -rf dts/* && tsc",
     "test": "mocha ./dist/test"
+  },
+  "peerDependencies": {
+    "joi": "^17.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/Interfaces/index.ts
+++ b/src/Interfaces/index.ts
@@ -21,7 +21,7 @@ import {
   WhenSchemaOptions,
   Context,
   ReferenceOptions
-} from "@hapi/joi";
+} from "joi";
 
 export interface Reference extends Omit<ReferenceOptions, "adjust"> {
   $ref: string;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,4 @@
-import * as Joi from "@hapi/joi";
+import * as Joi from "joi";
 import {JsonRegex, Reference} from "./Interfaces";
 import {fromJson} from "./index";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as Joi from "@hapi/joi";
+import * as Joi from "joi";
 import {cloneDeep} from "lodash";
 import {isObject, regexToString, extractRef, jsonToRegex, jsonToRef, propertiesToJson, isStringFunction} from "./Utils";
 import {


### PR DESCRIPTION
@hapi.joi package has been deprecated https://www.npmjs.com/package/@hapi/joi
Changes:

- Changed '@hapi/joi' to 'joi'.
- Moved 'joi' dependency to the devDependencies and added it to the peerDependencies. It will allow using the same joi version for a client app, and this library
- Added @types/node. For some reason, it wasn't possible to build the project without @types/node.

p.s thank you for this library. It helps a lot.